### PR TITLE
add support for creating social users

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -22,7 +22,6 @@ var opts = {
   secret: 'testAuthLib',
   lookupAccount: lookupAccount,
   updateTokens: lodash.noop,
-  updateAccount: lodash.noop,
 };
 var auth = new AuthLib.Auth(opts);
 new AuthLib.Logins.local('local', auth);

--- a/lib/authLib.js
+++ b/lib/authLib.js
@@ -20,7 +20,6 @@ class AuthLib {
    * @param {function} opts.lookupAccount - lookup an account by id, email, or external account id
    * @param {function} [opts.registerExternalAccount] - registers a user coming from external account
    * @param {function} opts.updateTokens - updates refresh tokens associated with an account
-   * @param {function} opts.updateAccount - updates from external accounts
    */
   constructor(opts) {
     this.logins = [];
@@ -31,7 +30,6 @@ class AuthLib {
     this.opts.maxRefreshTokens = this.opts.maxRefreshTokens || 5;
     if(!this.opts.lookupAccount) throw new Error('opts.lookupAccount required');
     if(!this.opts.updateTokens) throw new Error('opts.updateTokens required');
-    if(!this.opts.updateAccount) throw new Error('opts.updateAccount required');
 
     if(!this.log) throw new Error('opts.log required');
   }

--- a/lib/logins/google.js
+++ b/lib/logins/google.js
@@ -49,9 +49,11 @@ class Google extends Login {
         // lookup internal user based on userInfo.id
         return this.authLib.opts.lookupAccount({google: userInfo.id});
       })
-      // TODO handle new user
       .then((user) => {
-        if(!user) throw new Error('creating users from social login not supported (yet)');
+        if(!user) {
+          return createNewUser(this.authLib, userInfo)
+            .then((newUser) => this.sendSuccess(req.body.access_type, res, newUser));
+        }
         if(!(user instanceof User)) {
           throw new Error('lookupAccount() retval must be subclass of user');
         }
@@ -73,6 +75,23 @@ class Google extends Login {
         return this.sendFail(res);
       });
   } 
+}
+
+function createNewUser(authLib, userInfo) {
+  if(!authLib.opts.registerExternalAccount) {
+    throw new Error('creating users from social login requires registerExternalAccount');
+  }
+
+  return authLib.opts.registerExternalAccount({google: userInfo})
+    .then((user) => {
+      user.social.googleID = userInfo.id;
+      for(var prop of ['name', 'email', 'picture']) {
+        user.social[prop] = userInfo[prop];
+      }
+      user.save();
+      authLib.log.error({user: user}, 'what does user look like now?');
+      return Promise.resolve(user);
+    });
 }
 
 module.exports = Google;

--- a/test/authConstructorOptions.js
+++ b/test/authConstructorOptions.js
@@ -16,7 +16,6 @@ var allOpts = {
   lookupAccount: lodash.noop,
   registerExternalAccount: lodash.noop,
   updateTokens: lodash.noop,
-  updateAccount: lodash.noop,
 };
 
 describe('auth constructor options', () => {
@@ -44,17 +43,7 @@ describe('auth constructor options', () => {
     a.opts.maxRefreshTokens.should.equal(5);
   });
 
-  it('invalid construction missing secret', () => {
-    var opts = lodash.clone(allOpts);
-    delete opts.secret;
-
-    return new Promise((resolve) => {
-      resolve(new Auth(opts));
-    })
-    .should.eventually.be.rejectedWith('opts.secret required');
-  });
-
-  var requiredFields = ['log', 'secret', 'lookupAccount', 'updateTokens', 'updateAccount'];
+  var requiredFields = ['log', 'secret', 'lookupAccount', 'updateTokens'];
   for (var field of requiredFields) {
     testMissingField(field);
   }

--- a/test/authLib.js
+++ b/test/authLib.js
@@ -15,7 +15,6 @@ describe('AuthLib', () => {
       secret: 'testAuthLib',
       lookupAccount: lodash.noop,
       updateTokens: lodash.noop,
-      updateAccount: lodash.noop,
     };
     authLib = new AuthLib.Auth(opts);
   });

--- a/test/encryptHelpers.js
+++ b/test/encryptHelpers.js
@@ -13,7 +13,6 @@ var opts = {
   log: log,
   lookupAccount: lodash.noop,
   updateTokens: lodash.noop,
-  updateAccount: lodash.noop,
 };
 var auth = new Auth(opts);
 

--- a/test/lib/simpleUserStore.js
+++ b/test/lib/simpleUserStore.js
@@ -49,18 +49,22 @@ class UserStore {
     return Promise.resolve(lodash.find(this.users, field));
   }
 
-  updateAccount(user, update) {
-    this.lookupAccount({id: user.id})
-      .then((u) => {
-        lodash.extend(u, update);
-      });
+  registerExternalAccount(accountInfo) {
+    var key = Object.keys(accountInfo)[0];
+    var obj = {
+      name: accountInfo[key].name,
+      id: key + ':' + accountInfo[key].id
+    };
+    var u = new SimpleUser(obj);
+    this.users.push(u);
+    return Promise.resolve(u);
   }
 
   createAuthLibOpts() {
     return {
       lookupAccount: this.lookupAccount.bind(this),
+      registerExternalAccount: this.registerExternalAccount.bind(this),
       updateTokens: lodash.noop,
-      updateAccount: this.updateAccount.bind(this),
     };
   }
 }

--- a/test/properUsage.js
+++ b/test/properUsage.js
@@ -17,7 +17,6 @@ describe('proper usage', () => {
           log: test.log,
           lookupAccount: () => Promise.resolve({name: 'Jane Doe', id: 12345}),
           updateTokens: lodash.noop,
-          updateAccount: lodash.noop,
         };
         auth = new AuthLib.Auth(opts);
         local = new AuthLib.Logins.local('local', auth);


### PR DESCRIPTION
- if a user doesn't exist and an optional registerExternalAccount method
  was registered as part of the auth options when creating the Auth object,
  register the new user and set the social parameters.
- remove some references to `updateAccount` which is no longer used
