### PR TITLE
support refresh tokens

### DIFF
--- a/lib/authLib.js
+++ b/lib/authLib.js
@@ -27,7 +27,9 @@ class AuthLib {
     this.opts = opts;
     this.opts.tokenDuration = this.opts.tokenDuration || 3600;
     if(!this.opts.secret) throw new Error('opts.secret required');
-    this.opts.maxRefreshTokens = this.opts.maxRefreshTokens || 5;
+    if(!lodash.isNumber(this.opts.maxRefreshTokens)) {
+      this.opts.maxRefreshTokens = 5;
+    }
     if(!this.opts.lookupAccount) throw new Error('opts.lookupAccount required');
     if(!this.opts.updateTokens) throw new Error('opts.updateTokens required');
 
@@ -87,9 +89,27 @@ class AuthLib {
       id: user.id,
     };
 
-    if(type === 'offline') throw new Error('offline token type not supported yet');
+    if(type === 'offline' && this.opts.maxRefreshTokens > 0) {
+      return this.getRefreshToken(user)
+        .then((refreshToken) => {
+          token.refresh_token = refreshToken;
+          return token;
+        });
+    }
 
-    return token;
+    return Promise.resolve(token);
+  }
+
+  getRefreshToken(user) {
+    var refreshObj = {
+      i: user.id,
+      n: Date.now(),
+    };
+    var refreshToken = this.encryptObject(refreshObj);
+    user.auth.refreshTokens.unshift(refreshToken);
+    user.auth.refreshTokens = lodash.take(user.auth.refreshTokens, this.opts.maxRefreshTokens);
+    return user.save()
+      .then(() => refreshToken);
   }
 
   initExpress(app) {
@@ -97,6 +117,10 @@ class AuthLib {
     var opts = {passReqToCallback: true};
     passport.use(new bearerStrategy(opts, validator));
     app.use(passport.initialize());
+
+    if(this.opts.maxRefreshTokens > 0) {
+      app.post('/auth/token', this.verifyToken.bind(this));
+    }
 
     lodash.forEach(this.logins, (login) => {
       this.log.error({type: login.constructor.name}, 'configuring route...');
@@ -108,6 +132,29 @@ class AuthLib {
     return (req, res, next) => {
       passport.authenticate('bearer', {session: false})(req, res, next);
     };
+  }
+
+  verifyToken(req, res) {
+    if(!req.body.refresh_token) return this._sendFail(res, 'missing token');
+    if(req.body.grant_type !== 'refresh_token') return this._sendFail(res, 'unsupported grant type');
+
+    Promise.resolve(this.decryptObject(req.body.refresh_token))
+      .then((token) => this.opts.lookupAccount({id: token.i}))
+      .then((user) => {
+        if(!lodash.contains(user.auth.refreshTokens, req.body.refresh_token)) {
+          throw new Error('refresh token not in users refresh set');
+        }
+        return this.getAccessToken(user, req.body.access_type)
+          .then(token => res.json(token));
+      })
+      .catch((e) => {
+        this.log.info({err: e}, 'verify token failed');
+        return this._sendFail(res, 'Unauthorized');
+      });
+  }
+
+  _sendFail(res, msg) {
+    return Promise.resolve(res.status(401).json({message: msg}));
   }
 
   _validateAccessToken(req, token, done) {

--- a/lib/logins/login.js
+++ b/lib/logins/login.js
@@ -40,8 +40,8 @@ class Login {
     @param user - user record for login
   */
   sendSuccess(accessType, res, user) {
-    var token = this.authLib.getAccessToken(user, accessType);
-    return res.json(token);
+    return this.authLib.getAccessToken(user, accessType)
+      .then(token => res.json(token));
   }
 
   /**
@@ -49,7 +49,7 @@ class Login {
     @param res - http response
   */
   sendFail(res) {
-    return res.status(401).json({message: 'Unauthorized'});
+    return Promise.resolve(res.status(401).json({message: 'Unauthorized'}));
   }
 }
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -11,7 +11,7 @@ class User {
    * preps authLib required data structures
    **/
   constructor() {
-    this.auth = {};
+    this.auth = {refreshTokens: []};
     this.social = {};
   }
 

--- a/test/lib/test.js
+++ b/test/lib/test.js
@@ -17,7 +17,7 @@ class Test {
 
     this.log = getLogger(name);
 
-    //this.users = new require('./simpleUserStore')();
+    this.users = new (require('./simpleUserStore'))();
   }
 
   createExpressServer() {

--- a/test/local.js
+++ b/test/local.js
@@ -26,6 +26,7 @@ describe('Local', () => {
     var opts = users.createAuthLibOpts();
     opts.log = log;
     opts.secret = 'testAuthLib';
+    opts.maxRefreshTokens = 0;
     auth = new AuthLib.Auth(opts);
     new AuthLib.Logins.local('local', auth);
     auth.initExpress(app);

--- a/test/refresh.js
+++ b/test/refresh.js
@@ -1,0 +1,158 @@
+var Test = require('./lib/test.js');
+
+var AuthLib = require('../lib');
+var request = require('request-promise');
+
+describe('refresh tokens', () => {
+  var test = new Test('refresh');
+  var auth;
+
+  before(() => {
+    return test.createExpressServer()
+      .then(() => {
+        var opts = test.users.createAuthLibOpts();
+        opts.log = test.log;
+        opts.secret = 'refresh';
+        opts.maxRefreshTokens = 2;
+        auth = new AuthLib.Auth(opts);
+        new AuthLib.Logins.local('local', auth);
+        auth.initExpress(test.app);
+        return test.users.addUser({id: 123, password: 'sekret', email: 'foo@svp'});
+      });
+  });
+
+  it('user should not have a refresh token', () => {
+    test.users.lookupAccount({id: 123})
+      .then((user) => {
+        user.should.have.deep.property('auth.refreshTokens');
+        user.auth.refreshTokens.length.should.equal(0);
+      });
+  });
+
+  var refreshToken;
+  it('get refresh token', () => {
+    return _getRefreshToken()
+      .then((token) => {
+        refreshToken = token;
+      })
+      .then(() => test.users.lookupAccount({id: 123}))
+      .then((user) => {
+        user.should.have.deep.property('auth.refreshTokens');
+        user.auth.refreshTokens.length.should.equal(1);
+        refreshToken.should.equal(user.auth.refreshTokens[0]);
+      });
+  });
+
+  it('can obtain access token from refresh token', () => {
+    var reqOpts = {
+      uri: test.appUrl + '/auth/token',
+      method: 'post',
+      json: {refresh_token: refreshToken, grant_type: 'refresh_token'},
+    };
+    return request(reqOpts)
+      .then((data) => {
+        data.should.have.property('access_token');
+        data.should.have.property('token_type', 'bearer');
+        data.should.have.property('expires_in', 3600);
+        data.should.have.property('id', 123);
+        data.should.not.have.property('refresh_token');
+      })
+      .then(() => test.users.lookupAccount({id: 123}))
+      .then((user) => {
+        user.should.have.deep.property('auth.refreshTokens');
+        user.auth.refreshTokens.length.should.equal(1);
+      });
+  });
+
+  it('/auth/token requires refresh_token', () => {
+    var reqOpts = {
+      uri: test.appUrl + '/auth/token',
+      method: 'post',
+      json: {opps_token: refreshToken, grant_type: 'refresh_token'},
+      simple: false,
+      resolveWithFullResponse: true,
+    };
+    return request(reqOpts)
+      .then((res) => {
+        res.statusCode.should.equal(401);
+        res.should.have.deep.property('body.message', 'missing token');
+      });
+  });
+
+  it('/auth/token with unsupported grant_type', () => {
+    var reqOpts = {
+      uri: test.appUrl + '/auth/token',
+      method: 'post',
+      json: {refresh_token: refreshToken, grant_type: 'oops'},
+      simple: false,
+      resolveWithFullResponse: true,
+    };
+    return request(reqOpts)
+      .then((res) => {
+        res.statusCode.should.equal(401);
+        res.should.have.deep.property('body.message', 'unsupported grant type');
+      });
+  });
+
+  it('get 2nd refresh token', () => {
+    var secondToken;
+    return _getRefreshToken()
+      .then((token) => {
+        secondToken = token;
+      })
+      .then(() => test.users.lookupAccount({id: 123}))
+      .then((user) => {
+        user.should.have.deep.property('auth.refreshTokens');
+        user.auth.refreshTokens.length.should.equal(2);
+        secondToken.should.equal(user.auth.refreshTokens[0]);
+        refreshToken.should.equal(user.auth.refreshTokens[1]);
+      });
+  });
+
+  it('get 3rd refresh token', () => {
+    var thirdToken;
+    return _getRefreshToken()
+      .then((token) => {
+        thirdToken = token;
+      })
+      .then(() => test.users.lookupAccount({id: 123}))
+      .then((user) => {
+        user.should.have.deep.property('auth.refreshTokens');
+        user.auth.refreshTokens.length.should.equal(2);
+        thirdToken.should.equal(user.auth.refreshTokens[0]);
+        refreshToken.should.not.equal(user.auth.refreshTokens[1]);
+      });
+  });
+
+  it('/auth/token with refresh token not in users list of refresh tokens', () => {
+    var reqOpts = {
+      uri: test.appUrl + '/auth/token',
+      method: 'post',
+      json: {refresh_token: refreshToken, grant_type: 'refresh_token'},
+      simple: false,
+      resolveWithFullResponse: true,
+    };
+    return request(reqOpts)
+      .then((res) => {
+        res.statusCode.should.equal(401);
+        res.should.have.deep.property('body.message', 'Unauthorized');
+      });
+  });
+
+  function _getRefreshToken() {
+    var reqOpts = {
+      uri: test.appUrl + '/auth/local/verify',
+      method: 'post',
+      json: {id: 123, password: 'sekret', access_type: 'offline'},
+    };
+    return request(reqOpts)
+      .then((data) => {
+        data.should.have.property('access_token');
+        data.should.have.property('token_type', 'bearer');
+        data.should.have.property('expires_in', 3600);
+        data.should.have.property('id', 123);
+        data.should.have.property('refresh_token');
+        return data.refresh_token;
+      });
+  }
+});

--- a/test/user.js
+++ b/test/user.js
@@ -28,7 +28,7 @@ describe('user', () => {
     u.should.have.property('foo', 'abc');
     u.should.have.property('bar', 123);
     u.should.have.property('auth');
-    u.auth.should.be.empty;
+    u.auth.should.deep.equal({refreshTokens: []});
     u.should.have.property('social');
     u.social.should.be.empty;
   });


### PR DESCRIPTION
- create a refresh token (simple encrypted object)
- store refresh token on user object
- add compare functions (need to add tests)
- add route /auth/token for exchanging refresh tokens for a new access token
- add tests to request refresh tokens
- add tests for retrieving access tokens from refresh tokens
