### PR TITLE
update node version in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.9.4
+      - image: circleci/node:14.16.1
       
     working_directory: ~/repo
 


### PR DESCRIPTION
Between when dependebot created PRs and now, CircleCI seems to fail due to the older version of Node. Upgrading this to LTS.