### PR TITLE
add rs256 signing algorithm support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
   "node": true,
+  "esversion": 9,
   "mocha": true,
   "indent": 2,
   "newcap": true,
@@ -7,7 +8,6 @@
   "undef": true,
   "lastsemic": true,
   "eqeqeq": true,
-  "esnext": true,
   "expr": true,
   "asi": true,
   "unused": true,

--- a/lib/authLib.js
+++ b/lib/authLib.js
@@ -29,7 +29,19 @@ class AuthLib {
     this.opts = opts;
     this.opts.tokenDuration = this.opts.tokenDuration || 3600;
     this.opts.refreshDuration = this.opts.refreshDuration || 0;
-    if(!this.opts.secret) throw new Error('opts.secret required');
+    this.opts.signAlg = this.opts.signAlg || 'HS256';
+    switch(this.opts.signAlg) {
+      case 'HS256':
+        if(!this.opts.secret) throw new Error('opts.secret required');
+        break;
+      case 'RS256':
+        if(!this.opts.keys) throw new Error('opts.keys required');
+        if(!this.opts.keys.public) throw new Error('opts.keys.public required');
+        if(!this.opts.keys.private) throw new Error('opts.keys.private required');
+        break;
+      default:
+        throw new Error('opts.signAlg, unknown signing algorithm')
+    }
     this.opts.maxRefreshTokens = this.opts.maxRefreshTokens || 5;
     if(!this.opts.lookupAccount) throw new Error('opts.lookupAccount required');
     if(!this.opts.updateTokens) throw new Error('opts.updateTokens required');
@@ -43,6 +55,9 @@ class AuthLib {
    * @returns {string} a base64 string of the input obj
    */
   encryptObject(obj) {
+    if(!this.opts.secret) {
+      throw new Error('encryption only supported if opts.secret configured');
+    }
     var buf = new Buffer(this.opts.secret);
     var cipher = crypto.createCipher('aes-256-cbc', buf);
     var encodedText = cipher.update(JSON.stringify(obj), 'utf8', 'base64');
@@ -83,9 +98,11 @@ class AuthLib {
   getAccessToken(user, type) {
     const jwtFields = (this.opts.getExtendedJWTFields) ? this.opts.getExtendedJWTFields(user) : {}
     jwtFields.id = user.id
+    const algorithm = this.opts.signAlg;
+    const key = algorithm === 'HS256' ? this.opts.secret : this.opts.keys.private;
 
-    var jwtOpts = {expiresIn: this.opts.tokenDuration, algorithm: 'HS256'};
-    var accessToken = jwt.sign(jwtFields, this.opts.secret, jwtOpts);
+    var jwtOpts = {expiresIn: this.opts.tokenDuration, algorithm};
+    var accessToken = jwt.sign(jwtFields, key, jwtOpts);
     var token = {
       access_token: accessToken,
       token_type: 'bearer',
@@ -98,7 +115,7 @@ class AuthLib {
       if(this.opts.refreshDuration) {
         refreshOpts.expiresIn =  this.opts.refreshDuration;
       }
-      token.refresh_token = jwt.sign(jwtFields, this.opts.secret, refreshOpts);
+      token.refresh_token = jwt.sign(jwtFields, key, refreshOpts);
       this.opts.updateTokens(user, token.refresh_token);
     }
 
@@ -126,7 +143,9 @@ class AuthLib {
   _validateAccessToken(req, token, done) {
     var obj;
     try {
-      obj = jwt.verify(token, this.opts.secret, {algorithms: ['HS256']});
+      const algorithms = [this.opts.signAlg];
+      const key = this.opts.signAlg === 'HS256' ? this.opts.secret : this.opts.keys.private;
+      obj = jwt.verify(token, key, {algorithms});
     } catch(err) {
       this.log.info({err: err}, 'token err');
       // null/undefined user in done() is handled as unauthenticated by passport

--- a/test/lib/generateRSA.js
+++ b/test/lib/generateRSA.js
@@ -1,0 +1,19 @@
+const { generateKeyPair } = require('crypto');
+
+function generateRSAKeys() {
+  const opts = {
+    modulusLength: 4096,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  };
+  return new Promise((resolve, reject) => {
+    generateKeyPair('rsa', opts, (err, pubKey, privKey) => {
+      if(err) {
+        return reject(err);
+      }
+      resolve({ public: pubKey, private: privKey });
+    });
+  });
+}
+
+module.exports = generateRSAKeys;

--- a/test/rs256TokenAlg.js
+++ b/test/rs256TokenAlg.js
@@ -1,0 +1,115 @@
+var AuthLib = require('../lib');
+var express = require('express');
+var bodyParser = require('body-parser');
+var http = require('http');
+var request = require('request-promise');
+var lolex = require('lolex');
+
+const generateRSAKeys = require('./lib/generateRSA');
+var chai = require('chai');
+chai.use(require('chai-as-promised'));
+chai.should();
+var getLogger = require('./lib/getLogger');
+var portFinder = require('svp-portfinder');
+var UserStore = require('./lib/simpleUserStore');
+
+describe('rs256', () => {
+  var app = express();
+  var server = http.createServer(app);
+  app.use(bodyParser.urlencoded({extended: true}));
+  app.use(bodyParser.json());
+
+  var auth, url, log, users;
+
+  before(async () => {
+    log = getLogger('rs256');
+
+    users = new UserStore();
+    var opts = users.createAuthLibOpts();
+    opts.log = log;
+    opts.signAlg = 'RS256';
+    opts.keys = await generateRSAKeys();
+    auth = new AuthLib.Auth(opts);
+    new AuthLib.Logins.local('local', auth);
+    auth.initExpress(app);
+
+    app.get('/private', auth.addAuthMiddleware(), (req, res) => {
+      res.json({user: req.user});
+    });
+
+    var setupServer = portFinder()
+      .then((port) => {
+        url = 'http://localhost:' + port;
+        return new Promise((resolve, reject) => {
+          server.listen(port);
+          server.on('listening', resolve);
+          server.on('error', reject);
+        });
+      });
+    var setupUser = users.addUser({id: 123, password: 'secret2', email: 'foo@svp.com'});
+    return Promise.all([setupServer, setupUser]);
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  var bearer;
+  it('login', () => {
+    var reqOpts = {
+      uri: url + '/auth/local/verify',
+      method: 'post',
+      json: {id: 123, password: 'secret2'}
+    };
+    return request(reqOpts)
+      .then((data) => {
+        bearer = data.access_token;
+      });
+  });
+
+  it('access auth-protected api', () => {
+    var reqOpts = {
+      uri: url + '/private',
+      auth: {'bearer': bearer},
+    };
+    return request(reqOpts)
+      .then((data) => {
+        log.error({data: data}, 'private api response');
+        var body = JSON.parse(data);
+        body.should.have.nested.property('user.id', 123);
+      });
+  });
+
+  it('bad token is denied', () => {
+    var reqOpts = {
+      uri: url + '/private',
+      auth: {'bearer': bearer + 'foo'},
+      simple: false,
+      resolveWithFullResponse: true,
+    };
+    return request(reqOpts)
+      .then((data) => {
+        log.error({data: data}, 'private api response - bad token');
+        data.should.have.property('statusCode', 401);
+        data.should.have.property('body', 'Unauthorized');
+      });
+  });
+
+  it('expired token is denied', () => {
+    // fast forward one hour + 1ms, using lolex
+    var clock = lolex.install(Date.now() + 3600*1000 + 1);
+    var reqOpts = {
+      uri: url + '/private',
+      auth: {'bearer': bearer},
+      simple: false,
+      resolveWithFullResponse: true,
+    };
+    return request(reqOpts)
+      .then((data) => {
+        log.error({data: data}, 'private api response - bad token');
+        data.should.have.property('statusCode', 401);
+        data.should.have.property('body', 'Unauthorized');
+        clock.uninstall();
+      });
+  });
+});


### PR DESCRIPTION
* adds new options to authLib to support specifying the signing
  algorithm (HS256, default and what was used previously; or RS256
  public / private keys). Options include: `signAlg`, `keys.public`,
  and `keys.private`. The secret option is required only if the signAlg
  is HS256 now; and the keys.[public,private] are required if the
  signAlg is RS256.
* update signing & verification of tokens for the RS256 algorithm
* add tests for the RS256 signing algorithm (and various options
  configurations).

NOTE: the tests in particular use ES9 syntax. This modifies the jshint
lint checks to allow ES9.