### PR TITLE
better RS256 signing support

### DIFF
--- a/lib/authLib.js
+++ b/lib/authLib.js
@@ -38,6 +38,11 @@ class AuthLib {
         if(!this.opts.keys) throw new Error('opts.keys required');
         if(!this.opts.keys.public) throw new Error('opts.keys.public required');
         if(!this.opts.keys.private) throw new Error('opts.keys.private required');
+
+        // create a key id
+        const hash = crypto.createHash('sha256');
+        hash.update(this.opts.keys.public);
+        this.kid = hash.digest('base64');
         break;
       default:
         throw new Error('opts.signAlg, unknown signing algorithm')
@@ -95,13 +100,19 @@ class AuthLib {
     return obj;
   }
 
-  getAccessToken(user, type) {
+  getAccessToken(user, type, issuer) {
     const jwtFields = (this.opts.getExtendedJWTFields) ? this.opts.getExtendedJWTFields(user) : {}
     jwtFields.id = user.id
+    if(!jwtFields.iss && issuer) {
+      jwtFields.iss = issuer;
+    }
     const algorithm = this.opts.signAlg;
     const key = algorithm === 'HS256' ? this.opts.secret : this.opts.keys.private;
 
     var jwtOpts = {expiresIn: this.opts.tokenDuration, algorithm};
+    if(algorithm === 'RS256') {
+      jwtOpts.keyid = this.kid;
+    }
     var accessToken = jwt.sign(jwtFields, key, jwtOpts);
     var token = {
       access_token: accessToken,
@@ -111,9 +122,15 @@ class AuthLib {
     };
 
     if(type === 'offline') {
-      const refreshOpts = {algorithm, issuer: 'authlib'};
+      const refreshOpts = {algorithm};
       if(this.opts.refreshDuration) {
         refreshOpts.expiresIn =  this.opts.refreshDuration;
+      }
+      if(!jwtFields.iss) {
+        jwtFields.iss = issuer || 'authLib';
+      }
+      if(algorithm === 'RS256') {
+        refreshOpts.keyid = this.kid;
       }
       token.refresh_token = jwt.sign(jwtFields, key, refreshOpts);
       this.opts.updateTokens(user, token.refresh_token);

--- a/lib/logins/login.js
+++ b/lib/logins/login.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const crypto = require('crypto');
+const { fromKeyLike } = require('jose/jwk/from_key_like');
+
 /**
  * abstract base class for logging in
  */
@@ -21,16 +24,38 @@ class Login {
     @param app - express app
   */
   configureRoute(app) {
+    const storeIssuer = (req, res, next) => {
+      const host = req.headers['x-forwarded-host'] || req.headers.host;
+      res.locals.issuer = `${req.protocol}://${host}/auth/${this.loginName}`;
+      next();
+    };
     // configure username/password route
     var v = this.verify.bind(this);
     this.authLib.log.info('adding route to app');
-    app.post('/auth/' + this.loginName + '/verify', v);
+    const loginRoute = '/auth/' + this.loginName + '/verify';
+    app.use(loginRoute, storeIssuer);
+    app.post(loginRoute, v);
 
     // configure refreshtoken route
     if(this.verifyRefresh) {
       this.authLib.log.info('configuring refresh token route');
       var vr = this.verifyRefresh.bind(this);
-      app.post('/auth/' + this.loginName + '/token', vr);
+      const refreshRoute = '/auth/' + this.loginName + '/token';
+      app.use(refreshRoute, storeIssuer);
+      app.post(refreshRoute, vr);
+    }
+
+    // configure well known routes if signing algorithm is RS256
+    if(this.authLib.opts.signAlg === 'RS256') {
+      this.authLib.log.info('adding openid + jwks routes');
+      app.get(
+        '/auth/' + this.loginName + '/.well-known/openid-configuration',
+        this.openIDConfiguration.bind(this)
+      );
+      app.get(
+        '/auth/' + this.loginName + '/.well-known/jwks.json',
+        this.getKeySet.bind(this)
+      );
     }
   }
 
@@ -42,13 +67,41 @@ class Login {
   }
 
   /**
+    send openIDConfiguration
+  */
+  openIDConfiguration(req, res) {
+    const host = req.headers['x-forwarded-host'] || req.headers.host;
+    return res.json({
+      jwks_uri: `${req.protocol}://${host}/auth/${this.loginName}/.well-known/jwks.json`,
+    });
+  }
+
+  /**
+    get the jsonwebtoken keyset for RS256 public key
+
+    clients use this API to obtain the public key which allows them to verify that
+    the entity using this authLibrary generated the tokens
+  */
+  getKeySet(req, res) {
+    const key = crypto.createPublicKey(this.authLib.opts.keys.public);
+    fromKeyLike(key).then((publicJwk) => {
+      publicJwk.alg = 'RS256';
+      publicJwk.use = 'sig';
+      publicJwk.kid = this.authLib.kid;
+      return res.json({
+        keys: [publicJwk],
+      });
+    });
+  }
+
+  /**
     send response to login the user (verify succeeded)
     @param accessType - offline 
     @param res - http response
     @param user - user record for login
   */
   sendSuccess(accessType, res, user) {
-    var token = this.authLib.getAccessToken(user, accessType);
+    var token = this.authLib.getAccessToken(user, accessType, res.locals.issuer);
     return res.json(token);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1556,6 +1556,11 @@
         }
       }
     },
+    "jose": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-3.12.3.tgz",
+      "integrity": "sha512-PtT5I/omolkItXxKu+BhyrBhoYpmJAIPiG+W00BwZ4I3gT9rl8pLnK5cs2ha0LAknMxLVvM3UexcuYwNUkQ7aw=="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bcryptjs": "^2.2.1",
     "body-parser": "^1.14.0",
     "express": "^4.13.3",
+    "jose": "^3.12.3",
     "jsonwebtoken": "^8.5.0",
     "lodash": "^4.17.21",
     "passport": "^0.4.0",


### PR DESCRIPTION
This improves the auth-libraries RS256 signing. Changes:

* Allow applications to override the issuer manually, although this
should not be required in general.
  * override is handled by using getExtendedJWTFields; however, this
  should rarely be needed; by default can capture this from the
  route/controller for logging in.
* The configured routes now include well-known OpenID configurations for
jwks support. This should enable applications to sign the JWTs and have
them verified by third parties without providing public keys to the
third parties.
* Adds a calculation of a keyid/kid that is used in the JWTs.
* Adds tests for new endpoints + more validation on existing tests.